### PR TITLE
#17 - Multi-component key support

### DIFF
--- a/zcl_abapgit_object_by_sobj.clas.locals_def.abap
+++ b/zcl_abapgit_object_by_sobj.clas.locals_def.abap
@@ -196,4 +196,12 @@ CLASS lcl_tlogo_bridge DEFINITION.
         cs_objkey        TYPE lcl_tlogo_bridge=>ty_s_objkey
         cv_non_value_pos TYPE numc3.
 
+    methods distribute_name_to_components
+      IMPORTING
+        it_key_component TYPE lcl_tlogo_bridge=>ty_s_object_table-field_catalog
+      CHANGING
+        ct_objkey        TYPE lcl_tlogo_bridge=>ty_t_objkey
+        cs_objkey        TYPE lcl_tlogo_bridge=>ty_s_objkey
+        cv_non_value_pos TYPE numc3.
+
 ENDCLASS.

--- a/zcx_abapgit_object.clas.abap
+++ b/zcx_abapgit_object.clas.abap
@@ -21,7 +21,7 @@ ENDCLASS.
 CLASS ZCX_ABAPGIT_OBJECT IMPLEMENTATION.
 
 
-  METHOD constructor.
+  METHOD constructor ##ADT_SUPPRESS_GENERATION.
     CALL METHOD super->constructor
       EXPORTING
         previous = previous.


### PR DESCRIPTION
Fixes #17

In some object types, the object name comprises multiple fields (e. g. WDCC).
Thus, the name needs to be split up to the components in order to create a proper select-clause