### PR TITLE
Fix exception text in local exception class

### DIFF
--- a/src/zcl_abapgitp_object_by_sobj.clas.abap
+++ b/src/zcl_abapgitp_object_by_sobj.clas.abap
@@ -98,7 +98,7 @@ CLASS ZCL_ABAPGITP_OBJECT_BY_SOBJ IMPLEMENTATION.
         RAISE EXCEPTION TYPE zcx_abapgitp_object
           EXPORTING
             text     = |{ mv_obj_type } { mv_obj_name }: {
-                        lx_obj_exception->get_error_text( ) }|
+                        lx_obj_exception->get_text( ) }|
             previous = lx_obj_exception.
     ENDTRY.
 

--- a/src/zcl_abapgitp_object_by_sobj.clas.locals_def.abap
+++ b/src/zcl_abapgitp_object_by_sobj.clas.locals_def.abap
@@ -6,7 +6,7 @@ CLASS lcx_obj_exception DEFINITION INHERITING FROM cx_static_check.
         previous LIKE previous OPTIONAL
         iv_text  TYPE string OPTIONAL.
 
-    METHODS: get_error_text RETURNING VALUE(rv_text) TYPE string.
+    METHODS: get_text REDEFINITION.
 
   PROTECTED SECTION.
     DATA mv_text TYPE string.

--- a/src/zcl_abapgitp_object_by_sobj.clas.locals_imp.abap
+++ b/src/zcl_abapgitp_object_by_sobj.clas.locals_imp.abap
@@ -749,9 +749,9 @@ CLASS lcx_obj_exception IMPLEMENTATION.
     mv_text = iv_text.
   ENDMETHOD.
 
-  METHOD get_error_text.
+  METHOD get_text.
 * todo, perhaps remove mv_text attribute?
-    rv_text = mv_text.
+    result = mv_text.
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
Instead of adding new method get_exception_text, code has been changed to use the standard method get_text which should be used to fetch the text of any exception. Previously the implementation returns an empty string even though a message was set in the exception class. This is an issue if a calling class is looking into full exception stack to get all exception messages.