### PR TITLE
Fix where clause for tables with integer keys

### DIFF
--- a/src/zcl_abapgitp_object_by_sobj.clas.locals_imp.abap
+++ b/src/zcl_abapgitp_object_by_sobj.clas.locals_imp.abap
@@ -725,6 +725,12 @@ CLASS lcl_tlogo_bridge IMPLEMENTATION.
       ls_objkey_sub-value = |{ substring( val = cs_objkey-value off = lv_objkey_sub_pos len = lv_len ) }|.
       ls_objkey_sub-num = cv_non_value_pos.
 
+      IF  ls_key_component_uncovered-type_kind = cl_abap_typedescr=>typekind_int
+      AND condense( ls_objkey_sub-value ) CN '0123456789'.
+        " Avoid CONVT_NO_NUMBER dump for tables with INT-keys
+        CONTINUE.
+      ENDIF.
+
       INSERT ls_objkey_sub INTO TABLE ct_objkey.
 
       ADD ls_key_component_uncovered-length TO lv_objkey_sub_pos.

--- a/src/zcl_abapgitp_object_by_sobj.clas.testclasses.abap
+++ b/src/zcl_abapgitp_object_by_sobj.clas.testclasses.abap
@@ -1991,3 +1991,57 @@ CLASS ltcl_bobf IMPLEMENTATION.
   ENDMETHOD.
 
 ENDCLASS.
+
+
+" R3TR  SDPK  APO: Activities for Mass Processing Jobs
+"
+" Table /SAPAPO/TSPLBAKT
+" Keys:
+" MANDT  MANDT CLNT  3 0 0 Client
+" AKTKEY  /SAPAPO/AKTKEY  CHAR  10  0 0 Planning Activity Key
+" AKCNT /SAPAPO/AKCNT INT4  10  0 0 Activity Sequence
+CLASS ltcl_SDPK DEFINITION FINAL FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS.
+
+  PRIVATE SECTION.
+    METHODS:
+      where_clause_trunc_non_int FOR TESTING RAISING cx_static_check,
+      where_clause_with_int FOR TESTING RAISING cx_static_check.
+
+    DATA mo_bridge TYPE REF TO lcl_test_bridge.
+ENDCLASS.
+
+
+CLASS ltcl_SDPK IMPLEMENTATION.
+
+  METHOD where_clause_trunc_non_int.
+
+    CREATE OBJECT mo_bridge
+      EXPORTING
+        iv_object      = 'SDPK'
+        iv_object_name = 'ZOBJUT_TEST_DUMMY'.
+
+    cl_abap_unit_assert=>assert_equals(
+       msg = 'Where clause not expected'
+       exp = |MANDT = '{ sy-mandt }' AND AKTKEY = 'ZOBJUT_TES'|
+       act = mo_bridge->expose_where_clause( '/SAPAPO/TSPLBAKT' ) ).
+
+  ENDMETHOD.
+
+
+  METHOD where_clause_with_int.
+
+    CREATE OBJECT mo_bridge
+      EXPORTING
+        iv_object      = 'SDPK'
+        iv_object_name = 'ZOBJUT_TES1234'.
+
+    cl_abap_unit_assert=>assert_equals(
+       msg = 'Where clause not expected'
+       exp = |MANDT = '{ sy-mandt }' AND AKTKEY = 'ZOBJUT_TES' AND AKCNT = '1234'|
+       act = mo_bridge->expose_where_clause( '/SAPAPO/TSPLBAKT' ) ).
+
+  ENDMETHOD.
+
+ENDCLASS.


### PR DESCRIPTION
fixes this error from abapGit repo [5798](https://github.com/abapGit/abapGit/issues/5798)
![grafik](https://user-images.githubusercontent.com/17437789/193836611-6b271821-3d81-4b1d-aaf5-615fb8dcb106.png)

![grafik](https://user-images.githubusercontent.com/17437789/193836804-76128e43-ad37-4558-8a49-b39a3b87c92b.png)
![grafik](https://user-images.githubusercontent.com/17437789/193836856-bd1b4218-ec9a-4387-b9e3-4b3c72a0b1b4.png)

![grafik](https://user-images.githubusercontent.com/17437789/193836948-16186702-cd80-4250-ab1a-ab4dc7e9441d.png)
